### PR TITLE
Update dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bluebird": "^3.4.7",
     "lodash": "^4.17.4",
     "request": "^2.79.0",
-    "soap": "^0.18.0"
+    "soap": "^0.24.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Soap v0.19 (however I updated to 0.24) removes dependency to [ursa](https://github.com/JoshKaufman/ursa) which has build compatibility with node 10